### PR TITLE
fix: remove writev option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Create a new async iterable. The values yielded from calls to `.next()` or when 
 `options` is an _optional_ parameter, an object with the following properties:
 
 * `onEnd` - a function called after _all_ values have been yielded from the iterator (including buffered values). In the case when the iterator is ended with an error it will be passed the error as a parameter.
-* `writev` - a boolean used to signal that the consumer of this iterable supports processing multiple buffered chunks at a time. When this option is set to `true` values yielded from the iterable will be arrays.
 
 Note: the `onEnd` function may be passed instead of `options`.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,24 +1,15 @@
-export interface Pushable<T> extends AsyncIterable<T> {
-  push: (value: T) => this,
-  end: (err?: Error) => this
+declare namespace pushable {
+  export interface Pushable<T> extends AsyncIterable<T> {
+    push: (value: T) => this,
+    end: (err?: Error) => this
+  }
+
+  type Options = {
+    onEnd?: (err?: Error) => void,
+    writev?: false
+  }
 }
 
-export interface PushableV<T> extends AsyncIterable<T[]> {
-  push: (value: T) => this,
-  end: (err?: Error) => this
-}
-
-type Options = {
-  onEnd?: (err?: Error) => void,
-  writev?: false
-}
-
-type OptionsV = {
-  onEnd?: (err?: Error) => void,
-  writev: true
-}
-
-declare function pushable<T> (options?: Options): Pushable<T>
-declare function pushable<T> (options: OptionsV): PushableV<T>
+declare function pushable<T> (options?: pushable.Options): pushable.Pushable<T>
 
 export = pushable

--- a/index.js
+++ b/index.js
@@ -16,17 +16,6 @@ module.exports = (options) => {
 
   const waitNext = () => {
     if (!buffer.isEmpty()) {
-      if (options.writev) {
-        let next
-        const values = []
-        while (!buffer.isEmpty()) {
-          next = buffer.shift()
-          if (next.error) throw next.error
-          values.push(next.value)
-        }
-        return { done: next.done, value: values }
-      }
-
       const next = buffer.shift()
       if (next.error) throw next.error
       return next
@@ -40,11 +29,7 @@ module.exports = (options) => {
         if (next.error) {
           reject(next.error)
         } else {
-          if (options.writev && !next.done) {
-            resolve({ done: next.done, value: [next.value] })
-          } else {
-            resolve(next)
-          }
+          resolve(next)
         }
         return pushable
       }

--- a/test.js
+++ b/test.js
@@ -226,32 +226,3 @@ test.cb('should call onEnd by calling throw', t => {
     source.throw(new Error('boom'))
   })()
 })
-
-test('should support writev', async t => {
-  const source = pushable({ writev: true })
-  const input = [1, 2, 3]
-  input.forEach(v => source.push(v))
-  setTimeout(() => source.end())
-  const output = await pipe(source, collect)
-  t.deepEqual(output[0], input)
-})
-
-test('should always yield arrays when using writev', async t => {
-  const source = pushable({ writev: true })
-  const input = [1, 2, 3]
-  setTimeout(() => {
-    input.forEach(v => source.push(v))
-    setTimeout(() => source.end())
-  })
-  const output = await pipe(source, collect)
-  output.forEach(v => t.true(Array.isArray(v)))
-})
-
-test('should support writev and end with error', async t => {
-  const source = pushable({ writev: true })
-  const input = [1, 2, 3]
-  input.forEach(v => source.push(v))
-  source.end(new Error('boom'))
-  const err = await t.throwsAsync(pipe(source, collect))
-  t.deepEqual(err.message, 'boom')
-})


### PR DESCRIPTION
If you need to batch up pushed items, use [it-pipe](https://www.npmjs.com/package/it-pipe)
along with [it-batch](https://www.npmjs.com/package/it-batch) or
[streaming-iterables.batch](https://www.npmjs.com/package/streaming-iterables#batch)
or similar to compose the behaviour.

Fixes #9