### PR TITLE
fix: types again

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,24 +1,26 @@
-export interface Pushable<T> extends AsyncIterable<T> {
-  push: (value: T) => this,
-  end: (err?: Error) => this
+declare namespace pushable {
+  export interface Pushable<T> extends AsyncIterable<T> {
+    push: (value: T) => this,
+    end: (err?: Error) => this
+  }
+
+  export interface PushableV<T> extends AsyncIterable<T[]> {
+    push: (value: T) => this,
+    end: (err?: Error) => this
+  }
+
+  type Options = {
+    onEnd?: (err?: Error) => void,
+    writev?: false
+  }
+
+  type OptionsV = {
+    onEnd?: (err?: Error) => void,
+    writev: true
+  }
 }
 
-export interface PushableV<T> extends AsyncIterable<T[]> {
-  push: (value: T) => this,
-  end: (err?: Error) => this
-}
-
-type Options = {
-  onEnd?: (err?: Error) => void,
-  writev?: false
-}
-
-type OptionsV = {
-  onEnd?: (err?: Error) => void,
-  writev: true
-}
-
-declare function pushable<T> (options?: Options): Pushable<T>
-declare function pushable<T> (options: OptionsV): PushableV<T>
+declare function pushable<T> (options?: pushable.Options): pushable.Pushable<T>
+declare function pushable<T> (options: pushable.OptionsV): pushable.PushableV<T>
 
 export = pushable


### PR DESCRIPTION
Wraps everything in a namespace and exports the pushable function.

I think this is what @hugomrdias [meant](https://github.com/alanshaw/it-pushable/issues/8#issuecomment-765906896) but my ts-fu is weak sauce.

Fixes #8