### PR TITLE
feat: support backpressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Output:
 
 Create a new async iterable. The values yielded from calls to `.next()` or when used in a `for await of` loop are "pushed" into the iterable. Returns an async iterable object with the following additional methods:
 
-* `.push(value)` - push a value into the iterable. Values are yielded from the iterable in the order they are pushed. Values not yet consumed from the iterable are buffered
+* `.push(value)` - push a value into the iterable. Values are yielded from the iterable in the order they are pushed. Values not yet consumed from the iterable are buffered up to the high water mark if set. Returns a promise that resolves once the value has been added to the internal queue ready to be consumed.
 * `.end([err])` - end the iterable after all values in the buffer (if any) have been yielded. If an error is passed the buffer is cleared immediately and the next iteration will throw the passed error
 
 `options` is an _optional_ parameter, an object with the following properties:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # it-pushable
 
 [![Build Status](https://github.com/alanshaw/it-pushable/actions/workflows/js-test-and-release.yml/badge.svg?branch=master)](https://github.com/alanshaw/it-pushable/actions/workflows/js-test-and-release.yml)
-[![Dependencies Status](https://david-dm.org/alanshaw/it-pushable/status.svg)](https://david-dm.org/alanshaw/it-pushable)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
 > An iterable that you can push values into
@@ -18,6 +17,30 @@ npm install it-pushable
 import { pushable } from 'it-pushable'
 
 const source = pushable()
+await source.push(Uint8Array.from([0]))
+await source.push(Uint8Array.from([1]))
+await source.push(Uint8Array.from([2]))
+await source.end()
+
+for await (const arr of source) {
+  console.log(arr)
+}
+/*
+Output:
+Uint8Array[0]
+Uint8Array[1]
+Uint8Array[2]
+*/
+```
+
+We can also push non-`Uint8Array`s by specifying the `objectMode` option:
+
+```js
+import { pushable } from 'it-pushable'
+
+const source = pushable({
+  objectMode: true
+})
 
 setTimeout(() => source.push('hello'), 100)
 setTimeout(() => source.push('world'), 200)
@@ -42,12 +65,14 @@ done after 309ms
 import { pushableV } from 'it-pushable'
 import all from 'it-all'
 
-const source = pushableV()
+const source = pushableV({
+  objectMode: true
+})
 
-source.push(1)
-source.push(2)
-source.push(3)
-source.end()
+await source.push(1)
+await source.push(2)
+await source.push(3)
+await source.end()
 
 console.info(await all(source))
 /*
@@ -68,6 +93,8 @@ Create a new async iterable. The values yielded from calls to `.next()` or when 
 `options` is an _optional_ parameter, an object with the following properties:
 
 * `onEnd` - a function called after _all_ values have been yielded from the iterator (including buffered values). In the case when the iterator is ended with an error it will be passed the error as a parameter.
+* `objectMode` - a boolean value that means non-`Uint8Array`s will be passed to `.push`, default: `false`
+* `highWaterMark` - a threshold beyond which calls to `.push` will wait for previously pushed items to be consumed.  If `objectMode` is `false`, this number is interpreted as the total number of bytes that the queue should hold, otherwise it is the number of items in the queue
 
 ### `pushableV([options])`
 

--- a/package.json
+++ b/package.json
@@ -137,5 +137,8 @@
   "bugs": {
     "url": "https://github.com/alanshaw/it-pushable/issues"
   },
-  "homepage": "https://github.com/alanshaw/it-pushable#readme"
+  "homepage": "https://github.com/alanshaw/it-pushable#readme",
+  "dependencies": {
+    "p-defer": "^4.0.0"
+  }
 }

--- a/src/fifo.ts
+++ b/src/fifo.ts
@@ -1,85 +1,93 @@
-// ported from https://www.npmjs.com/package/fast-fifo
+import defer, { DeferredPromise } from 'p-defer'
 
-class FixedFIFO<T> {
-  public buffer: Array<T | undefined>
-  private readonly mask: number
-  private top: number
-  private btm: number
-  public next: FixedFIFO<T> | null
+export interface Next<T> {
+  done?: boolean
+  error?: Error
+  value?: T
+}
 
-  constructor (hwm: number) {
-    if (!(hwm > 0) || ((hwm - 1) & hwm) !== 0) {
-      throw new Error('Max size for a FixedFIFO should be a power of two')
-    }
+export type NextResult<T> = { done: false, value: T} | { done: true }
 
-    this.buffer = new Array(hwm)
-    this.mask = hwm - 1
-    this.top = 0
-    this.btm = 0
-    this.next = null
-  }
-
-  push (data: T) {
-    if (this.buffer[this.top] !== undefined) {
-      return false
-    }
-
-    this.buffer[this.top] = data
-    this.top = (this.top + 1) & this.mask
-
-    return true
-  }
-
-  shift () {
-    const last = this.buffer[this.btm]
-
-    if (last === undefined) {
-      return undefined
-    }
-
-    this.buffer[this.btm] = undefined
-    this.btm = (this.btm + 1) & this.mask
-    return last
-  }
-
-  isEmpty () {
-    return this.buffer[this.btm] === undefined
-  }
+export interface FIFOOptions {
+  highWaterMark?: number
+  objectMode?: boolean
 }
 
 export class FIFO<T> {
-  private readonly hwm: number
-  private head: FixedFIFO<T>
-  private tail: FixedFIFO<T>
+  private readonly objectMode: boolean
+  private readonly highWaterMark: number
+  private queue: Array<Next<T>>
+  private deferred?: DeferredPromise<void>
+  private size: number
 
-  constructor (hwm?: number) {
-    this.hwm = hwm ?? 16
-    this.head = new FixedFIFO<T>(this.hwm)
-    this.tail = this.head
+  constructor (options: FIFOOptions = {}) {
+    this.objectMode = Boolean(options.objectMode)
+    this.highWaterMark = options.highWaterMark ?? Infinity
+    this.queue = []
+    this.size = 0
   }
 
-  push (val: T) {
-    if (!this.head.push(val)) {
-      const prev = this.head
-      this.head = prev.next = new FixedFIFO<T>(2 * this.head.buffer.length)
-      this.head.push(val)
+  async push (val: Next<T>) {
+    if (this.size < this.highWaterMark) {
+      this.queue.push(val)
+
+      if (val.done === false) {
+        if (this.objectMode) {
+          this.size++
+        } else if (val.value instanceof Uint8Array) {
+          this.size += val.value.byteLength
+        } else {
+          throw new Error('objectMode was false but tried to push non-Uint8Array value')
+        }
+      }
+
+      return
     }
+
+    // wait for a slot in the queue to become available
+    this.deferred = defer()
+    await this.deferred.promise
+
+    // try again
+    await this.push(val)
   }
 
-  shift () {
-    const val = this.tail.shift()
+  shift (): Next<T> | undefined {
+    const val = this.queue.shift()
 
-    if (val === undefined && (this.tail.next != null)) {
-      const next = this.tail.next
-      this.tail.next = null
-      this.tail = next
-      return this.tail.shift()
+    if (val === undefined) {
+      return undefined
+    }
+
+    if (val.done === false) {
+      if (this.objectMode) {
+        this.size--
+      } else if (val.value instanceof Uint8Array) {
+        this.size -= val.value.byteLength
+      } else {
+        throw new Error('objectMode was false but tried to shift non-Uint8Array value')
+      }
+    }
+
+    if (this.deferred != null) {
+      this.deferred.resolve()
+      this.deferred = undefined
     }
 
     return val
   }
 
   isEmpty () {
-    return this.head.isEmpty()
+    return this.queue.length === 0
+  }
+
+  clear () {
+    if (this.deferred != null) {
+      this.deferred.resolve()
+      this.deferred = undefined
+    }
+
+    this.queue = []
+    this.size = 0
   }
 }

--- a/src/fifo.ts
+++ b/src/fifo.ts
@@ -45,7 +45,10 @@ export class FIFO<T> {
     }
 
     // wait for a slot in the queue to become available
-    this.deferred = defer()
+    if (this.deferred == null) {
+      this.deferred = defer()
+    }
+
     await this.deferred.promise
 
     // try again

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -420,6 +420,21 @@ describe('it-pushable', () => {
     // @ts-expect-error incorrect argument type
     await expect(source.push('hello')).to.eventually.be.rejected.with.property('message').that.includes('tried to push non-Uint8Array value')
   })
+
+  it('should push values over the high water mark without awaiting', async () => {
+    const highWaterMark = 1
+    const source = pushable<number>({
+      highWaterMark,
+      objectMode: true
+    })
+
+    void source.push(1)
+    void source.push(2)
+    void source.push(3)
+    void source.end()
+
+    await expect(all(source)).to.eventually.deep.equal([1, 2, 3])
+  })
 })
 
 async function pTimeout <T> (p: Promise<T>, timeout: number): Promise<T> {

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -413,6 +413,13 @@ describe('it-pushable', () => {
     // should resolve now we've freed up space in the queue
     await expect(p).to.eventually.equal(source)
   })
+
+  it('should throw if passed an object when objectMode is false', async () => {
+    const source = pushable()
+
+    // @ts-expect-error incorrect argument type
+    await expect(source.push('hello')).to.eventually.be.rejected.with.property('message').that.includes('tried to push non-Uint8Array value')
+  })
 })
 
 async function pTimeout <T> (p: Promise<T>, timeout: number): Promise<T> {


### PR DESCRIPTION
At present the FIFO queue that this module uses is unbounded which means it can exhaust all available memory available to the process.

This PR adds `highWaterMark` and `objectMode` options similar to those found in node streams to allow us to constrain memory usage.

When `objectMode` is `false` (the default, like in node streams), `highWaterMark` is interpreted as the number of bytes that are allowed to be present in the queue.  When `objectMode` is `true`, `highWaterMark` is the number of objects that are allowed to be present in the queue.

If `objectMode` is `false` any attempt to `.push` a value that is not a `Uint8Array` will throw an error.

Backpressure is introduced in that promises returned from calls to `.push` will not resolve until there is space in the queue to accommodate the value passed to `.push`.

`.end` is also now async to ensure that the `{ done: true }` iterator result is pushed into the queue after all `{ done: false, value: ... }` results have been pushed.

It also swaps out the hand-rolled `Next` type for the built in `IteratorResult` so `pushable`/`pushableV`s can extend `AsyncGenerator`.

BREAKING CHANGE: This module now expects `Uint8Array`s to be pushed by default, pass `objectMode: true` to push objects and if consuming from typescript, use generics to specify the type of object