### PR TITLE
feat: add readableLength property

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,12 @@ Create a new async iterable. The values yielded from calls to `.next()` or when 
 
 * `.push(value)` - push a value into the iterable. Values are yielded from the iterable in the order they are pushed. Values not yet consumed from the iterable are buffered
 * `.end([err])` - end the iterable after all values in the buffer (if any) have been yielded. If an error is passed the buffer is cleared immediately and the next iteration will throw the passed error
+* `.readableLength` - a number that represents the size of the queue. if `objectMode` is true, this is the number of objects in the queue, if false it's the total number of bytes in the queue
 
 `options` is an _optional_ parameter, an object with the following properties:
 
 * `onEnd` - a function called after _all_ values have been yielded from the iterator (including buffered values). In the case when the iterator is ended with an error it will be passed the error as a parameter.
+* `objectMode` - a boolean value that means non-`Uint8Array`s will be passed to `.push`, default: `false`
 
 ### `pushableV([options])`
 

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -5,7 +5,9 @@ import all from 'it-all'
 
 describe('it-pushable', () => {
   it('should push input slowly', async () => {
-    const source = pushable()
+    const source = pushable<number>({
+      objectMode: true
+    })
     const input = [1, 2, 3]
     for (let i = 0; i < input.length; i++) {
       setTimeout(() => source.push(input[i]), i * 10)
@@ -16,7 +18,9 @@ describe('it-pushable', () => {
   })
 
   it('should buffer input', async () => {
-    const source = pushable()
+    const source = pushable<number>({
+      objectMode: true
+    })
     const input = [1, 2, 3]
     input.forEach(v => source.push(v))
     setTimeout(() => source.end())
@@ -25,7 +29,9 @@ describe('it-pushable', () => {
   })
 
   it('should buffer falsy input', async () => {
-    const source = pushable()
+    const source = pushable<number | undefined | null>({
+      objectMode: true
+    })
     const input = [1, 2, 3, undefined, null, 0, 4]
     input.forEach(v => source.push(v))
     setTimeout(() => source.end())
@@ -34,7 +40,9 @@ describe('it-pushable', () => {
   })
 
   it('should buffer some inputs', async () => {
-    const source = pushable<number | number[]>()
+    const source = pushable<number | number[]>({
+      objectMode: true
+    })
     const input = [1, [2.1, 2.2, 2.3], 3, 4, 5, [6.1, 6.2, 6.3, 6.4], 7]
     for (let i = 0; i < input.length; i++) {
       setTimeout(() => {
@@ -52,7 +60,9 @@ describe('it-pushable', () => {
   })
 
   it('should allow end before start', async () => {
-    const source = pushable()
+    const source = pushable<number>({
+      objectMode: true
+    })
     const input = [1, 2, 3]
     input.forEach(v => source.push(v))
     source.end()
@@ -61,7 +71,9 @@ describe('it-pushable', () => {
   })
 
   it('should end with error immediately', async () => {
-    const source = pushable()
+    const source = pushable<number>({
+      objectMode: true
+    })
     const input = [1, 2, 3]
     input.forEach(v => source.push(v))
     source.end(new Error('boom'))
@@ -71,7 +83,9 @@ describe('it-pushable', () => {
   })
 
   it('should end with error in the middle', async () => {
-    const source = pushable()
+    const source = pushable<number | Error>({
+      objectMode: true
+    })
     const input = [1, new Error('boom'), 3]
     for (let i = 0; i < input.length; i++) {
       setTimeout(() => {
@@ -97,7 +111,9 @@ describe('it-pushable', () => {
   })
 
   it('should allow next after end', async () => {
-    const source = pushable<number>()
+    const source = pushable<number>({
+      objectMode: true
+    })
     const input = [1]
     source.push(input[0])
     let next = await source.next()
@@ -111,7 +127,8 @@ describe('it-pushable', () => {
   })
 
   it('should call onEnd', (done) => {
-    const source = pushable({
+    const source = pushable<number>({
+      objectMode: true,
       onEnd: () => done()
     })
     const input = [1, 2, 3]
@@ -123,7 +140,10 @@ describe('it-pushable', () => {
   })
 
   it('should call onEnd if passed in options object', (done) => {
-    const source = pushable({ onEnd: () => done() })
+    const source = pushable<number>({
+      objectMode: true,
+      onEnd: () => done()
+    })
     const input = [1, 2, 3]
     for (let i = 0; i < input.length; i++) {
       setTimeout(() => source.push(input[i]), i * 10)
@@ -156,6 +176,7 @@ describe('it-pushable', () => {
     const output: number[] = []
 
     const source = pushable<number>({
+      objectMode: true,
       onEnd: () => {
         expect(output).to.deep.equal(input.slice(0, max))
         done()
@@ -181,6 +202,7 @@ describe('it-pushable', () => {
     const output: number[] = []
 
     const source = pushable<number>({
+      objectMode: true,
       onEnd: () => {
         expect(output).to.deep.equal(input.slice(0, max))
         done()
@@ -208,7 +230,8 @@ describe('it-pushable', () => {
     const input = [1, 2, 3, 4, 5]
 
     let count = 0
-    const source = pushable({
+    const source = pushable<number>({
+      objectMode: true,
       onEnd: () => {
         count++
         expect(count).to.equal(1)
@@ -231,6 +254,7 @@ describe('it-pushable', () => {
     const output: number[] = []
 
     const source = pushable<number>({
+      objectMode: true,
       onEnd: err => {
         expect(err).to.have.property('message', 'boom')
         expect(output).to.deep.equal(input.slice(0, max))
@@ -256,7 +280,9 @@ describe('it-pushable', () => {
   })
 
   it('should support writev', async () => {
-    const source = pushableV<number>()
+    const source = pushableV<number>({
+      objectMode: true
+    })
     const input = [1, 2, 3]
     input.forEach(v => source.push(v))
     setTimeout(() => source.end())
@@ -265,7 +291,9 @@ describe('it-pushable', () => {
   })
 
   it('should always yield arrays when using writev', async () => {
-    const source = pushableV<number>()
+    const source = pushableV<number>({
+      objectMode: true
+    })
     const input = [1, 2, 3]
     setTimeout(() => {
       input.forEach(v => source.push(v))
@@ -276,12 +304,59 @@ describe('it-pushable', () => {
   })
 
   it('should support writev and end with error', async () => {
-    const source = pushableV<number>()
+    const source = pushableV<number>({
+      objectMode: true
+    })
     const input = [1, 2, 3]
     input.forEach(v => source.push(v))
     source.end(new Error('boom'))
 
     await expect(pipe(source, async (source) => await all(source)))
       .to.eventually.be.rejected.with.property('message', 'boom')
+  })
+
+  it('should support readableLength for objects', async () => {
+    const source = pushable<number>({
+      objectMode: true
+    })
+
+    expect(source).to.have.property('readableLength', 0)
+
+    await source.push(1)
+    expect(source).to.have.property('readableLength', 1)
+
+    await source.push(1)
+    expect(source).to.have.property('readableLength', 2)
+
+    await source.next()
+    expect(source).to.have.property('readableLength', 1)
+
+    await source.next()
+    expect(source).to.have.property('readableLength', 0)
+  })
+
+  it('should support readableLength for bytes', async () => {
+    const source = pushable()
+
+    expect(source).to.have.property('readableLength', 0)
+
+    await source.push(Uint8Array.from([1, 2]))
+    expect(source).to.have.property('readableLength', 2)
+
+    await source.push(Uint8Array.from([3, 4, 5]))
+    expect(source).to.have.property('readableLength', 5)
+
+    await source.next()
+    expect(source).to.have.property('readableLength', 3)
+
+    await source.next()
+    expect(source).to.have.property('readableLength', 0)
+  })
+
+  it('should throw if passed an object when objectMode is false', async () => {
+    const source = pushable()
+
+    // @ts-expect-error incorrect argument type
+    expect(() => source.push('hello')).to.throw().with.property('message').that.includes('tried to push non-Uint8Array value')
   })
 })


### PR DESCRIPTION
Adds a `readableLength` property that tells you the current state of the queue.

Also adds an `objectMode` option similar to that found in node streams.

If `objectMode` is `true`, `readableLength` is the number of objects in the queue.

If `objectMode` is `false` (the default), only `Uint8Array`s can be passed to `.push` and `readableLength` is the total number of bytes in the queue.

BREAKING CHANGE: `Uint8Array`s are expected by default, pass `objectMode: true` to push any other data types. If using TypeScript, use generics to define the data type.