### PR TITLE
feat: support Uint8ArrayLists in the same way as Uint8Arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,8 @@
     "@types/fast-fifo": "^1.0.0",
     "aegir": "^37.0.17",
     "it-all": "^1.0.6",
-    "it-pipe": "^2.0.0"
+    "it-pipe": "^2.0.0",
+    "uint8arraylist": "^2.0.0"
   },
   "repository": {
     "type": "git",

--- a/src/fifo.ts
+++ b/src/fifo.ts
@@ -72,8 +72,8 @@ export class FIFO<T> {
     this.size = 0
   }
 
-  calculateSize (obj: any): number {
-    if (obj.byteLength != null) {
+  calculateSize (obj: T | { byteLength: number }): number {
+    if (obj != null && 'byteLength' in obj && obj.byteLength != null) {
       return obj.byteLength
     }
 

--- a/src/fifo.ts
+++ b/src/fifo.ts
@@ -72,8 +72,8 @@ export class FIFO<T> {
     this.size = 0
   }
 
-  calculateSize (obj: T | { byteLength: number }): number {
-    if (obj != null && 'byteLength' in obj && obj.byteLength != null) {
+  calculateSize (obj: any): number {
+    if (obj?.byteLength != null) {
       return obj.byteLength
     }
 

--- a/src/fifo.ts
+++ b/src/fifo.ts
@@ -59,7 +59,7 @@ export interface FIFOOptions {
   splitLimit?: number
 }
 
-export class FIFO<T extends any | { byteLength: number }> {
+export class FIFO<T> {
   public size: number
   private readonly hwm: number
   private head: FixedFIFO<T>

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export interface BytePushableOptions extends Options {
   objectMode?: false
 }
 
-export function pushable (options?: BytePushableOptions): Pushable<Uint8Array>
+export function pushable<T extends { byteLength: number } = Uint8Array> (options?: BytePushableOptions): Pushable<T>
 export function pushable<T> (options: ObjectPushableOptions): Pushable<T>
 export function pushable<T> (options: Options = {}): Pushable<T> {
   const getNext = (buffer: FIFO<T>): NextResult<T> => {
@@ -57,7 +57,7 @@ export function pushable<T> (options: Options = {}): Pushable<T> {
   return _pushable<T, T, Pushable<T>>(getNext, options)
 }
 
-export function pushableV (options?: BytePushableOptions): PushableV<Uint8Array>
+export function pushableV<T extends { byteLength: number } = Uint8Array> (options?: BytePushableOptions): PushableV<T>
 export function pushableV<T> (options: ObjectPushableOptions): PushableV<T>
 export function pushableV<T> (options: Options = {}): PushableV<T> {
   const getNext = (buffer: FIFO<T>): NextResult<T[]> => {
@@ -97,7 +97,7 @@ export function pushableV<T> (options: Options = {}): PushableV<T> {
 function _pushable<PushType, ValueType, ReturnType> (getNext: getNext<PushType, ValueType>, options?: Options): ReturnType {
   options = options ?? {}
   let onEnd = options.onEnd
-  let buffer = new FIFO<PushType>(options)
+  let buffer = new FIFO<PushType>()
   let pushable: any
   let onNext: ((next: Next<PushType>) => ReturnType) | null
   let ended: boolean
@@ -150,6 +150,11 @@ function _pushable<PushType, ValueType, ReturnType> (getNext: getNext<PushType, 
   const push = (value: PushType) => {
     if (ended) {
       return pushable
+    }
+
+    // @ts-expect-error `byteLength` is not declared on PushType
+    if (options?.objectMode !== true && value.byteLength == null) {
+      throw new Error('objectMode was not true but tried to push non-Uint8Array value')
     }
 
     return bufferNext({ done: false, value })

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,7 @@ function _pushable<PushType, ValueType, ReturnType> (getNext: getNext<PushType, 
     }
 
     // @ts-expect-error `byteLength` is not declared on PushType
-    if (options?.objectMode !== true && value.byteLength == null) {
+    if (options?.objectMode !== true && value?.byteLength == null) {
       throw new Error('objectMode was not true but tried to push non-Uint8Array value')
     }
 

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'aegir/chai'
 import { pipe } from 'it-pipe'
 import { pushable, pushableV } from '../src/index.js'
 import all from 'it-all'
+import { Uint8ArrayList } from 'uint8arraylist'
 
 describe('it-pushable', () => {
   it('should push input slowly', async () => {
@@ -359,7 +360,43 @@ describe('it-pushable', () => {
     expect(source).to.have.property('readableLength', 0)
   })
 
-  it('should throw if passed an object when objectMode is false', async () => {
+  it('should support readableLength for Uint8ArrayLists', async () => {
+    const source = pushable<Uint8ArrayList>()
+
+    expect(source).to.have.property('readableLength', 0)
+
+    await source.push(new Uint8ArrayList(Uint8Array.from([1, 2])))
+    expect(source).to.have.property('readableLength', 2)
+
+    await source.push(new Uint8ArrayList(Uint8Array.from([3, 4, 5])))
+    expect(source).to.have.property('readableLength', 5)
+
+    await source.next()
+    expect(source).to.have.property('readableLength', 3)
+
+    await source.next()
+    expect(source).to.have.property('readableLength', 0)
+  })
+
+  it('should support readableLength for mixed Uint8ArrayLists and Uint8Arrays', async () => {
+    const source = pushable<Uint8ArrayList | Uint8Array>()
+
+    expect(source).to.have.property('readableLength', 0)
+
+    await source.push(new Uint8ArrayList(Uint8Array.from([1, 2])))
+    expect(source).to.have.property('readableLength', 2)
+
+    await source.push(Uint8Array.from([3, 4, 5]))
+    expect(source).to.have.property('readableLength', 5)
+
+    await source.next()
+    expect(source).to.have.property('readableLength', 3)
+
+    await source.next()
+    expect(source).to.have.property('readableLength', 0)
+  })
+
+  it('should throw if passed an object when objectMode is not true', async () => {
     const source = pushable()
 
     // @ts-expect-error incorrect argument type


### PR DESCRIPTION
In order to support no-copy operations, relax the requirement for `Uint8Array`s to just require a `.byteLength` property since that's all we access.

Generics can then be used to ensure the correct value type is used as normal.

Everything still defaults to `Uint8Array`s so this is non-breaking.