### PR TITLE
feat: add a `.drain` promise to notify when the queue is empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,5 +148,8 @@
     "it-all": "^3.0.1",
     "it-pipe": "^3.0.1",
     "uint8arraylist": "^2.0.0"
+  },
+  "dependencies": {
+    "p-defer": "^4.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,7 @@ function _pushable<PushType, ValueType, ReturnType> (getNext: getNext<PushType, 
       if (buffer.isEmpty()) {
         // settle promise in the microtask queue to give consumers a chance to
         // await after calling .push
-        Promise.resolve().then(() => {
+        void Promise.resolve().then(() => {
           drain.resolve()
           drain = deferred()
           pushable.drain = drain.promise
@@ -230,7 +230,7 @@ function _pushable<PushType, ValueType, ReturnType> (getNext: getNext<PushType, 
           if (buffer.isEmpty()) {
             // settle promise in the microtask queue to give consumers a chance to
             // await after calling .push
-            Promise.resolve().then(() => {
+            void Promise.resolve().then(() => {
               drain.resolve()
               drain = deferred()
               pushable.drain = drain.promise

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,7 +211,7 @@ function _pushable<PushType, ValueType, ReturnType> (getNext: getNext<PushType, 
       if (buffer.isEmpty()) {
         // settle promise in the microtask queue to give consumers a chance to
         // await after calling .push
-        void Promise.resolve().then(() => {
+        queueMicrotask(() => {
           drain.resolve()
           drain = deferred()
           pushable.drain = drain.promise
@@ -232,7 +232,7 @@ function _pushable<PushType, ValueType, ReturnType> (getNext: getNext<PushType, 
           if (buffer.isEmpty()) {
             // settle promise in the microtask queue to give consumers a chance to
             // await after calling .push
-            void Promise.resolve().then(() => {
+            queueMicrotask(() => {
               drain.resolve()
               drain = deferred()
               pushable.drain = drain.promise

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -402,4 +402,61 @@ describe('it-pushable', () => {
     // @ts-expect-error incorrect argument type
     expect(() => source.push('hello')).to.throw().with.property('message').that.includes('tried to push non-Uint8Array value')
   })
+
+  it('should settle the empty promise when the pushable becomes empty', async () => {
+    const source = pushable<number>({
+      objectMode: true
+    })
+
+    let resolved = false
+
+    const p = source.drain.then(() => {
+      resolved = true
+    })
+
+    source.push(1)
+    expect(resolved).to.be.false()
+
+    source.push(2)
+    expect(resolved).to.be.false()
+
+    void source.next()
+    expect(resolved).to.be.false()
+
+    void source.next()
+    expect(resolved).to.be.false()
+
+    void source.next()
+
+    await p
+
+    expect(resolved).to.be.true()
+  })
+
+  it('should settle the empty promise when the pushableV becomes empty', async () => {
+    const source = pushableV<number>({
+      objectMode: true
+    })
+
+    let resolved = false
+
+    const p = source.drain.then(() => {
+      resolved = true
+    })
+
+    source.push(1)
+    expect(resolved).to.be.false()
+
+    source.push(2)
+    expect(resolved).to.be.false()
+
+    void source.next()
+    expect(resolved).to.be.false()
+
+    void source.next()
+
+    await p
+
+    expect(resolved).to.be.true()
+  })
 })


### PR DESCRIPTION
In order to know when all data in the underlying queue has been consumed, this PR adds a `.drain` promise that resolves when the queue becomes empty.

This is so callers can take action after `.end` has been called and all data has been consumed.