### PR TITLE
feat: add onEmpty function that resolves when the queue is empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,5 +148,8 @@
     "it-all": "^3.0.1",
     "it-pipe": "^3.0.1",
     "uint8arraylist": "^2.0.0"
+  },
+  "dependencies": {
+    "p-defer": "^4.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -349,7 +349,7 @@ function _pushable<PushType, ValueType, ReturnType> (getNext: getNext<PushType, 
         ])
       } finally {
         if (listener != null && signal != null) {
-          signal.removeEventListener('abort', listener)
+          signal?.removeEventListener('abort', listener)
         }
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -322,7 +322,7 @@ function _pushable<PushType, ValueType, ReturnType> (getNext: getNext<PushType, 
       }
 
       let cancel: Promise<void> | undefined
-      let listener: () => void | undefined
+      let listener: (() => void) | undefined
 
       if (signal != null) {
         cancel = new Promise((resolve, reject) => {

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -467,7 +467,7 @@ describe('it-pushable', () => {
     source.push(1)
 
     const controller = new AbortController()
-    const p = source.onEmpty(controller.signal)
+    const p = source.onEmpty({ signal: controller.signal })
 
     source.push(2)
 


### PR DESCRIPTION
Alternative to #57 which adds a function that resolves when the queue is empty and takes an optional `AbortSignal` to stop waiting.

```js
await pushable.onEmpty(abortSignal)
```