### PR TITLE
feat!: support backpressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [Install](#install)
   - [Browser `<script>` tag](#browser-script-tag)
 - [Usage](#usage)
+  - [Backpressure](#backpressure)
 - [Related](#related)
 - [API Docs](#api-docs)
 - [License](#license)
@@ -71,6 +72,35 @@ console.info(await all(source))
 Output:
 [ [1, 2, 3] ]
 */
+```
+
+### Backpressure
+
+This module supports backpressure by returning a promise to any `push` or `end`
+call.
+
+These promises will resolve when the `push`ed value has been consumed (in the
+case of `.push`) or when the consumer has iterated over all values in the
+pushable (in the case of `.end`).
+
+If you do not wish to wait and instead buffer as much data as possible, do not
+await the result of `.push`
+
+```js
+import { pushable } from 'it-pushable'
+
+const source = pushable()
+
+// wait for the value to be consumed
+await source.push(5)
+
+// do not wait for the value to be consumed
+void source.push(5)
+
+// only wait 10ms for the value to be consumed
+await source.push(5, {
+  signal: AbortSignal.timeout(10)
+})
 ```
 
 ## Related

--- a/package.json
+++ b/package.json
@@ -140,7 +140,8 @@
     "docs": "aegir docs"
   },
   "dependencies": {
-    "p-defer": "^4.0.0"
+    "p-defer": "^4.0.0",
+    "race-signal": "^1.0.1"
   },
   "devDependencies": {
     "@types/fast-fifo": "^1.0.0",

--- a/src/p-fifo.ts
+++ b/src/p-fifo.ts
@@ -1,0 +1,74 @@
+// ported from https://www.npmjs.com/package/p-fifo
+
+import defer from 'p-defer'
+import { FIFO } from './fifo.js'
+
+interface Consumer<T> {
+  resolve(value?: T | PromiseLike<T> | undefined): void
+}
+
+interface Chunk<T> {
+  chunk: T
+  resolve(value?: T): void
+}
+
+function calculateSize (obj: any): number {
+  if (obj?.chunk?.value?.byteLength != null) {
+    return obj.chunk.value.byteLength
+  }
+
+  return 1
+}
+
+export class PFIFO<T> {
+  private readonly buffer: FIFO<Chunk<T>>
+  private readonly waitingConsumers: FIFO<Consumer<T>>
+
+  constructor () {
+    this.buffer = new FIFO({
+      calculateSize
+    })
+    this.waitingConsumers = new FIFO()
+  }
+
+  async push (chunk: T): Promise<T> {
+    const { promise, resolve } = defer<T>()
+    this.buffer.push({ chunk, resolve })
+    this._consume()
+    return promise
+  }
+
+  _consume (): void {
+    while (!this.waitingConsumers.isEmpty() && !this.buffer.isEmpty()) {
+      const nextConsumer = this.waitingConsumers.shift()
+
+      if (nextConsumer == null) {
+        return
+      }
+
+      const nextChunk = this.buffer.shift()
+
+      if (nextChunk == null) {
+        return
+      }
+
+      nextConsumer.resolve(nextChunk.chunk)
+      nextChunk.resolve()
+    }
+  }
+
+  async shift (): Promise<T> {
+    const { promise, resolve } = defer<T>()
+    this.waitingConsumers.push({ resolve })
+    this._consume()
+    return promise
+  }
+
+  isEmpty (): boolean {
+    return this.buffer.isEmpty()
+  }
+
+  get size (): number {
+    return this.buffer.size
+  }
+}

--- a/test/fifo.spec.ts
+++ b/test/fifo.spec.ts
@@ -1,0 +1,152 @@
+import { expect } from 'aegir/chai'
+import { FIFO } from '../src/fifo.js'
+
+describe('fifo', () => {
+  it('basic', function () {
+    const q = new FIFO()
+    const values: any[] = [
+      1,
+      4,
+      4,
+      0,
+      null,
+      {},
+      Math.random(),
+      '',
+      'hello',
+      9,
+      1,
+      4,
+      5,
+      6,
+      7,
+      null,
+      null,
+      0,
+      0,
+      15,
+      52.2,
+      null
+    ]
+
+    expect(q.shift()).to.be.undefined()
+    expect(q.isEmpty()).to.be.true()
+    expect(q.size).to.equal(0)
+
+    for (const value of values) {
+      q.push(value)
+    }
+
+    expect(q.size).to.equal(values.length)
+
+    while (!q.isEmpty()) {
+      expect(q.shift()).to.deep.equal(values.shift())
+      expect(q.size).to.equal(values.length)
+    }
+
+    expect(q.shift()).to.be.undefined()
+    expect(q.isEmpty()).to.be.true()
+  })
+
+  it('long length', function () {
+    const q = new FIFO<number>()
+
+    const len = 0x8f7
+    for (let i = 0; i < len; i++) {
+      q.push(i)
+    }
+
+    expect(q.size).to.equal(len)
+
+    let shifts = 0
+    while (!q.isEmpty()) {
+      q.shift()
+      shifts++
+    }
+
+    expect(shifts).to.equal(len)
+    expect(q.size).to.equal(0)
+  })
+
+  it('clear', function () {
+    const q = new FIFO<string>()
+
+    q.push('a')
+    q.push('a')
+    q.clear()
+
+    expect(q.shift()).to.be.undefined()
+    expect(q.size).to.equal(0)
+
+    for (let i = 0; i < 50; i++) {
+      q.push('a')
+    }
+
+    q.clear()
+
+    expect(q.shift()).to.be.undefined()
+    expect(q.size).to.equal(0)
+  })
+
+  it('basic length', function () {
+    const q = new FIFO<string>()
+
+    q.push('a')
+    expect(q.size).to.equal(1)
+
+    q.push('a')
+    expect(q.size).to.equal(2)
+
+    q.shift()
+    expect(q.size).to.equal(1)
+
+    q.shift()
+    expect(q.size).to.equal(0)
+
+    q.shift()
+    expect(q.size).to.equal(0)
+  })
+
+  it('peek', function () {
+    const q = new FIFO<string>()
+
+    q.push('a')
+    expect(q.size).to.equal(1)
+    expect(q.peek()).to.deep.equal('a')
+    expect(q.peek()).to.deep.equal('a')
+
+    q.push('b')
+    expect(q.size).to.equal(2)
+    expect(q.peek()).to.deep.equal('a')
+    expect(q.peek()).to.deep.equal('a')
+
+    expect(q.shift()).to.deep.equal('a')
+    expect(q.peek()).to.deep.equal('b')
+    expect(q.peek()).to.deep.equal('b')
+
+    expect(q.shift()).to.deep.equal('b')
+    expect(q.peek()).to.be.undefined()
+    expect(q.peek()).to.be.undefined()
+  })
+
+  it('peek edgecase', function () {
+    const q = new FIFO<string>({ splitLimit: 4 })
+
+    q.push('a')
+    q.push('b')
+    q.push('c')
+    q.push('d')
+    q.push('e')
+
+    expect(q.peek()).to.equal(q.shift())
+    expect(q.peek()).to.equal(q.shift())
+    expect(q.peek()).to.equal(q.shift())
+    expect(q.peek()).to.equal(q.shift())
+    expect(q.peek()).to.equal(q.shift())
+    expect(q.peek()).to.equal(q.shift())
+  })
+
+  it('invalid hwm', function () {
+    expect(() => new FIFO({ splitLimit: 3 })).to.throw()
+  })
+})

--- a/test/p-fifo.spec.ts
+++ b/test/p-fifo.spec.ts
@@ -1,0 +1,69 @@
+import { expect } from 'aegir/chai'
+import { PFIFO } from '../src/p-fifo.js'
+
+const randomInt = (min: number, max: number): number => {
+  min = Math.ceil(min)
+  max = Math.floor(max)
+  return Math.floor(Math.random() * (max - min)) + min
+}
+
+describe('pfifo', () => {
+  it('should await for shift', async () => {
+    const fifo = new PFIFO<number>()
+    const input = Math.random()
+
+    setTimeout(() => {
+      void fifo.push(input)
+    }, 10)
+
+    await expect(fifo.shift()).to.eventually.equal(input)
+  })
+
+  it('should await for push', async () => {
+    const fifo = new PFIFO<number>()
+    const input = Math.random()
+
+    setTimeout(() => {
+      void fifo.shift().then(output => {
+        expect(output).to.equal(input)
+      })
+    }, 10)
+
+    await fifo.push(input)
+  })
+
+  it('should consume values in parallel from a full buffer', async () => {
+    const fifo = new PFIFO<number>()
+    const input = Array.from(Array(randomInt(5, 100)), () => Math.random())
+
+    input.forEach(v => {
+      void fifo.push(v)
+    })
+
+    const output = await Promise.all(input.map(async () => fifo.shift()))
+
+    expect(output).to.deep.equal(input)
+  })
+
+  it('should await all pushed values', async () => {
+    const fifo = new PFIFO()
+    const input = Array.from(Array(randomInt(5, 100)), () => Math.random())
+
+    const pushPromises = input.map(async v => fifo.push(v))
+
+    setTimeout(() => {
+      input.slice(0, -1).forEach(() => {
+        void fifo.shift()
+      })
+    }, 10)
+
+    setTimeout(() => {
+      expect(fifo.isEmpty()).to.be.false()
+      input.slice(-1).forEach(() => {
+        void fifo.shift()
+      })
+    }, 50)
+
+    await Promise.all(pushPromises)
+  })
+})


### PR DESCRIPTION
Incorporates the suggestion from #1 to support backpressure via returning a promise from `.push` and `.end` methods.

Removes the `onEmpty` function as this was a quick hack to simulate backpressure (e.g. `.push`, then await `.onEmpty`).

Adds a `.pushV` method to `pushableV` to guarantee all values make it into the buffer in a single asynchronous operation.

Ports `p-fifo` to typescript and adds test suites from that and the `fast-fifo` module.

Closes #1

BREAKING CHANGE: `.push` and `.end` now return promises, `.onEmpty` has been removed